### PR TITLE
fix(gpt-scraper-core): do not retry if invalid schema message arrives

### DIFF
--- a/packages/gpt-scraper-core/src/crawler.ts
+++ b/packages/gpt-scraper-core/src/crawler.ts
@@ -9,7 +9,7 @@ import {
     getNumberOfTextTokens,
     getOpenAIClient,
     validateGPTModel,
-    rethrowOpenaiError,
+    tryWrapInOpenaiError,
     OpenaiAPIUsage,
 } from './openai.js';
 import {
@@ -151,9 +151,11 @@ export const createCrawler = async ({ input }: { input: Input }) => {
                 jsonAnswer = answerResult.jsonAnswer;
                 openaiUsage.logApiCallUsage(answerResult.usage);
             } catch (err: any) {
-                const error = rethrowOpenaiError(err);
+                const error = tryWrapInOpenaiError(err);
                 if (error instanceof OpenaiAPIError && error.message.includes('Invalid schema')) {
-                    request.noRetry = true;
+                    // TODO: find a way to validate schema before running the actor
+                    // see #12
+                    throw await Actor.fail(error.message);
                 }
                 throw error;
             }

--- a/packages/gpt-scraper-core/src/openai.ts
+++ b/packages/gpt-scraper-core/src/openai.ts
@@ -119,7 +119,7 @@ export const validateGPTModel = (model: string) => {
     return modelConfig;
 };
 
-export const rethrowOpenaiError = (error: any) => {
+export const tryWrapInOpenaiError = (error: any) => {
     if (error?.response?.data?.error) {
         return new OpenaiAPIError(error.response.data.error.message || error.response.data.error.code);
     }


### PR DESCRIPTION
(draft) Currently only disables retrying if OpenAI tells that the schema is wrong, but cannot check it upfront