### PR TITLE
feat: dynamically switch to residential proxies

### DIFF
--- a/actors/gpt-scraper/.actor/input_schema.json
+++ b/actors/gpt-scraper/.actor/input_schema.json
@@ -114,16 +114,8 @@
             "editor": "textfield",
             "default": "0"
         },
-        "proxyConfiguration": {
-            "sectionCaption": "Advanced configuration",
-            "title": "Proxy configuration",
-            "type": "object",
-            "description": "Specifies proxy servers that will be used by the scraper in order to hide its origin.<br><br>For details, see <a href='https://apify.com/drobnikj/gpt-scraper#proxy-configuration' target='_blank' rel='noopener'>Proxy configuration</a> in README.",
-            "prefill": { "useApifyProxy": true },
-            "default": { "useApifyProxy": false },
-            "editor": "proxy"
-        },
         "pageFormatInRequest": {
+            "sectionCaption": "Advanced configuration",
             "title": "Page format in request",
             "type": "string",
             "description": "In what format to send the content extracted from the page to the GPT. Markdown will take less space allowing for larger requests, while HTML may help include some information like attributes that may otherwise be omitted.",

--- a/actors/gpt-scraper/src/input.ts
+++ b/actors/gpt-scraper/src/input.ts
@@ -4,4 +4,4 @@ import { Input as PackageInput } from '@packages/gpt-scraper-core';
  * Input schema in TypeScript format.
  * - Modify the core package schema to fit the Actor's input.
  */
-export type Input = Omit<PackageInput, 'openaiApiKey' | 'model'>
+export type Input = Omit<PackageInput, 'openaiApiKey' | 'model' | 'proxyConfiguration'>;

--- a/actors/gpt-scraper/src/main.ts
+++ b/actors/gpt-scraper/src/main.ts
@@ -33,6 +33,7 @@ if (process.env.OPENAI_API_KEY) {
             maxPagesPerCrawl: maxRequestsPerCrawl,
             model: DEFAULT_PEY_PER_RESULT_OPENAI_MODEL,
             openaiApiKey: process.env.OPENAI_API_KEY,
+            proxyConfiguration: undefined,
         },
     });
 

--- a/packages/gpt-scraper-core/src/hooks/proxy-manager-hooks.ts
+++ b/packages/gpt-scraper-core/src/hooks/proxy-manager-hooks.ts
@@ -1,0 +1,67 @@
+import { PlaywrightCrawlingContext, log } from 'crawlee';
+import { BLOCKED_STATUS_CODES, ProxyWebsiteStats } from '../proxy-manager.js';
+import { CrawlerState } from '../types/crawler-state.js';
+import { ProxyType } from '../types/proxy.js';
+import { ProxyUserData } from '../types/user-data.js';
+
+/**
+ * Assigns a proxy type to the request. If explicit proxy configuration is provided, it is used. Otherwise:
+ * - For the first request, the proxy type is picked based on the previous proxy stats for the given domain.
+ * - For second and subsequent requests, the proxy type is always residential.
+ */
+export const proxyManagerHook = async (context: PlaywrightCrawlingContext) => {
+    const { retryCount, url } = context.request;
+
+    const hasCustomProxySettings = await hasCustomProxyConfiguration(context);
+    if (hasCustomProxySettings) return;
+
+    const isFirstRequest = retryCount === 0;
+    if (!isFirstRequest) {
+        await assignProxyTypeToContext(context, ProxyType.RESIDENTIAL);
+        return;
+    }
+
+    const domain = new URL(url).hostname;
+
+    const proxyType = ProxyWebsiteStats.getProxyTypeToUseFromStats(domain);
+    await assignProxyTypeToContext(context, proxyType);
+};
+
+/**
+ * Logs the request's proxy type and success to the stats. Throws an error if the status code is blocked.
+ */
+export const proxyManagerPostHook = async (context: PlaywrightCrawlingContext) => {
+    const { request, response } = context as PlaywrightCrawlingContext<ProxyUserData>; // Crawlee doesn't have userData for hooks
+    const { url, userData } = request;
+
+    const hasCustomProxySettings = await hasCustomProxyConfiguration(context);
+    if (hasCustomProxySettings) return;
+
+    if (!response) return log.error(`No response for ${url}!`);
+
+    const domain = new URL(url).hostname;
+
+    const isBlocked = BLOCKED_STATUS_CODES.includes(response.status());
+    ProxyWebsiteStats.logRequest(domain, userData.proxyType, !isBlocked);
+
+    if (isBlocked) throw new Error(`Blocked. Response status code: ${response.status()}`);
+};
+
+const assignProxyTypeToContext = async (context: PlaywrightCrawlingContext, proxyType: ProxyType) => {
+    const { crawler, request } = context;
+    const { userData } = request;
+
+    const state = await crawler.useState<CrawlerState>();
+    const { proxies } = state.config;
+
+    userData.proxyType = proxyType;
+    context.proxyInfo = await proxies[proxyType]?.newProxyInfo();
+};
+
+const hasCustomProxyConfiguration = async (context: PlaywrightCrawlingContext) => {
+    const { crawler } = context;
+    const state = await crawler.useState<CrawlerState>();
+    const { proxyConfiguration } = state.config;
+
+    return !!proxyConfiguration;
+};

--- a/packages/gpt-scraper-core/src/proxy-manager.ts
+++ b/packages/gpt-scraper-core/src/proxy-manager.ts
@@ -1,0 +1,72 @@
+import { ProxyType } from './types/proxy.js';
+
+type WebsiteRequestStats = {
+    [key in ProxyType]: {
+        total: number;
+        successful: number;
+    };
+};
+
+export const BLOCKED_STATUS_CODES = [401, 403, 429, 503];
+
+export class ProxyWebsiteStats {
+    private static websiteRequestStats: { [domain: string]: WebsiteRequestStats } = {};
+
+    /**
+     * Gets the proxy type to use for the given domain. The proxy type is picked to bring the total requests ratio closer
+     * to the success rate ratio.
+     * - e.g.: Success rate ratio is `0.1 (data center) : 0.9 (residential) = 0.11` and the total requests ratio is
+     * `0.5 : 0.5 = 1`. Residential proxy type is picked because `0.11 < 1`. This will bring the total ratio closer to
+     * success ratio (e.g. `0.45 : 0.55 = 0.81`).
+     */
+    public static getProxyTypeToUseFromStats(domain: string): ProxyType {
+        if (!this.websiteRequestStats[domain]) {
+            this.initializeDomain(domain);
+            return ProxyType.DATA_CENTER;
+        }
+
+        const successRateRatio = this.getSuccessRateRatio(domain);
+        const totalRequestsRatio = this.getTotalRequestsRatio(domain);
+
+        const useDataCenter = successRateRatio > totalRequestsRatio;
+        return useDataCenter ? ProxyType.DATA_CENTER : ProxyType.RESIDENTIAL;
+    }
+
+    /**
+     * Logs the website request to the stats. The stats are later used to determine which proxy type to use.
+     */
+    public static logRequest(domain: string, proxyType: ProxyType, wasSuccess: boolean) {
+        const stats = this.websiteRequestStats[domain][proxyType];
+
+        stats.total++;
+        if (wasSuccess) stats.successful++;
+    }
+
+    /**
+     * Calculates the ratio success rate ratio between data center and residential proxies.
+     * - adds `1` to data center successful to avoid the ratio being `0`, since we would then always pick residential
+     */
+    private static getSuccessRateRatio(domain: string): number {
+        const dataCenter = this.websiteRequestStats[domain][ProxyType.DATA_CENTER];
+        const residential = this.websiteRequestStats[domain][ProxyType.RESIDENTIAL];
+
+        const dataCenterSuccessRate = (dataCenter.successful + 1) / dataCenter.total;
+        const residentialSuccessRate = residential.successful / residential.total;
+
+        return dataCenterSuccessRate / residentialSuccessRate;
+    }
+
+    private static getTotalRequestsRatio(domain: string): number {
+        const dataCenter = this.websiteRequestStats[domain][ProxyType.DATA_CENTER];
+        const residential = this.websiteRequestStats[domain][ProxyType.RESIDENTIAL];
+
+        return dataCenter.total / residential.total;
+    }
+
+    private static initializeDomain(domain: string) {
+        this.websiteRequestStats[domain] = {
+            [ProxyType.DATA_CENTER]: { total: 0, successful: 0 },
+            [ProxyType.RESIDENTIAL]: { total: 0, successful: 0 },
+        };
+    }
+}

--- a/packages/gpt-scraper-core/src/types/crawler-state.ts
+++ b/packages/gpt-scraper-core/src/types/crawler-state.ts
@@ -1,0 +1,12 @@
+import { ProxyConfiguration } from 'crawlee';
+import { Input } from './input.js';
+import { ProxyType } from './proxy.js';
+
+export interface CrawlerState {
+    pageOutputted: number;
+    config: { proxies: Proxies } & Input;
+}
+
+export type Proxies = {
+    [key in ProxyType]: ProxyConfiguration | undefined;
+};

--- a/packages/gpt-scraper-core/src/types/input.ts
+++ b/packages/gpt-scraper-core/src/types/input.ts
@@ -15,7 +15,7 @@ export interface Input extends OpenAIModelSettings {
     targetSelector?: string;
     maxPagesPerCrawl: number;
     maxCrawlingDepth: number;
-    proxyConfiguration: ProxyConfigurationOptions;
+    proxyConfiguration?: ProxyConfigurationOptions;
     schema?: AnySchema | undefined;
     useStructureOutput?: boolean;
     pageFormatInRequest?: PAGE_FORMAT;

--- a/packages/gpt-scraper-core/src/types/proxy.ts
+++ b/packages/gpt-scraper-core/src/types/proxy.ts
@@ -1,0 +1,4 @@
+export enum ProxyType {
+    DATA_CENTER,
+    RESIDENTIAL,
+}

--- a/packages/gpt-scraper-core/src/types/user-data.ts
+++ b/packages/gpt-scraper-core/src/types/user-data.ts
@@ -1,0 +1,5 @@
+import { ProxyType } from './proxy.js';
+
+export type ProxyUserData = {
+    proxyType: ProxyType;
+};


### PR DESCRIPTION
Resolves:
- #22

---
```
 * Assigns a proxy type to the request. If explicit proxy configuration is provided, it is used. Otherwise:
 * - For the first request, the proxy type is picked based on the previous proxy stats for the given domain.
 * - For second and subsequent requests, the proxy type is always residential.
```
```
 * Gets the proxy type to use for the given domain. The proxy type is picked to bring the total requests ratio closer
 * to the success rate ratio.
 * - e.g.: Success rate ratio is `0.1 (data center) : 0.9 (residential) = 0.11` and the total requests ratio is
 * `0.5 : 0.5 = 1`. Residential proxy type is picked because `0.11 < 1`. This will bring the total ratio closer to
 * success ratio (e.g. `0.45 : 0.55 = 0.81`).
 ```

It might be a bit overcomplicated, we could just use data center for first request and residentials for subsequent requests ¯\\\_(ツ)\_/¯ I'm thinking about this after implementing all of this :D