### PR TITLE
fix: handle repetitive prompt patterns OpenAI error

### DIFF
--- a/packages/gpt-scraper-core/src/errors.ts
+++ b/packages/gpt-scraper-core/src/errors.ts
@@ -1,5 +1,12 @@
 /* eslint-disable max-classes-per-file */
 
+export const REPETITIVE_PROMPT_ERROR_MESSAGE = 'OpenAI has rejected a page prompt because it contains repetitive '
+    + 'patterns. This usually happens when the website you are trying to scrape has some repetitive content. Please '
+    + 'try to remove the repetitive content via the `removeElementsCssSelector` input option. Skipping GPT processing '
+    + 'for this page!';
+
+export const ERROR_OCCURRED_MESSAGE = "An error has occurred in your run. Please check the run's logs for more info.";
+
 /**
  * Error from OpenAI API.
  */
@@ -17,9 +24,14 @@ export class OpenaiAPIError extends Error {
 }
 
 /**
- * Error from OpenAI API. This error indicates that the request should not be retried.
+ * Error from OpenAI API. Indicates that the request should not be retried.
  */
 export class NonRetryableOpenaiAPIError extends OpenaiAPIError {}
+
+/**
+ * Error from OpenAI API. Indicates that we should exit the Actor with it.
+ */
+export class OpenaiAPIErrorToExitActor extends NonRetryableOpenaiAPIError {}
 
 /**
  * Error from OpenAI API. Indicates that the request should be retried after a while.


### PR DESCRIPTION
fixes issues opened by some users:
https://console.apify.com/actors/paOtbjvyUiNsr1Qms/issues/weHU20mzDyo4acWxN
https://console.apify.com/actors/paOtbjvyUiNsr1Qms/issues/8LbRwYD6M76m2RiVu

---
This error is not documented in the OpenAI errors and there are only a few instances of it on the internet.
Basically OpenAI is trying to save credits of programmers who use repetitive and useless tokens in their inputs, i.e. wasting their prompt token usage. 
Unfortunately there doesn't seems to be any way to disable this... we simply have to skip GPT processing for requests that get this response.
Ultimately our users will have to identify what is repetitive on webpages they are trying to scrape and remove those elements using `removeElementsCssSelector` input option.