### PR TITLE
fix: scraping multiple URLs with disabled `saveSnapshots`

### DIFF
--- a/code/src/routes/crawl-route.ts
+++ b/code/src/routes/crawl-route.ts
@@ -119,10 +119,9 @@ export const crawlRoute = async (context: PlaywrightCrawlingContext<CrawlRouteUs
     const contentMaxTokens = model.modelConfig.maxTokens * 0.9 - instructionTokenLength; // 10% buffer for answer
     const pageContent = maybeShortsTextByTokenLength(originPageContent, contentMaxTokens);
 
-    let snapshotKey: string | undefined;
+    const snapshotKey = Date.now().toString();
     let sentContentKey: string | undefined;
     if (saveSnapshots) {
-        snapshotKey = Date.now().toString();
         sentContentKey = `${snapshotKey}-sentContent.${pageFormat === PAGE_FORMAT.MARKDOWN ? 'md' : 'html'}`;
         await utils.puppeteer.saveSnapshot(page, {
             key: snapshotKey,

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 This changelog tracks updates to both GTP Scraper and Extended GPT Scraper actors.
 
+# 2024-12-30
+*Fixes*
+- Fixed extraction of multiple URLs with disabled `saveSnapshots` option.
+
 # 2024-11-17
 *Features*
 - Improved GPT call handling, which should parallelize the calls together with the crawling better.


### PR DESCRIPTION
Fixes #90 